### PR TITLE
Decorated form elements in default CRUD templates

### DIFF
--- a/src/Mvc/Controller/Crud/views/edit.volt
+++ b/src/Mvc/Controller/Crud/views/edit.volt
@@ -30,7 +30,7 @@
                                                 {% endfor %}
                                             </span>
                                         {% endif %}
-                                        {{ element }}
+                                        {{ element.renderDecorated() }}
                                     </div>
                                 {% endfor %}
 

--- a/src/Mvc/Controller/Crud/views/edit.volt
+++ b/src/Mvc/Controller/Crud/views/edit.volt
@@ -30,7 +30,7 @@
                                                 {% endfor %}
                                             </span>
                                         {% endif %}
-                                        {{ element.renderDecorated() }}
+                                        {% if methodExists(element, 'renderDecorated') %}{{ element.renderDecorated() }}{% else %}{{ element }}{% endif %}
                                     </div>
                                 {% endfor %}
 

--- a/src/Mvc/Controller/Crud/views/new.volt
+++ b/src/Mvc/Controller/Crud/views/new.volt
@@ -30,7 +30,7 @@
                                                 {% endfor %}
                                             </span>
                                         {% endif %}
-                                        {{ element }}
+                                        {{ element.renderDecorated() }}
                                     </div>
                                 {% endfor %}
 

--- a/src/Mvc/Controller/Crud/views/new.volt
+++ b/src/Mvc/Controller/Crud/views/new.volt
@@ -30,7 +30,7 @@
                                                 {% endfor %}
                                             </span>
                                         {% endif %}
-                                        {{ element.renderDecorated() }}
+                                        {% if methodExists(element, 'renderDecorated') %}{{ element.renderDecorated() }}{% else %}{{ element }}{% endif %}
                                     </div>
                                 {% endfor %}
 

--- a/src/Mvc/View/Engine/Volt/Helper/MethodExists.php
+++ b/src/Mvc/View/Engine/Volt/Helper/MethodExists.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * This file is part of Vegas package
+ *
+ * @author Radosław Fąfara <radek@amsterdamstandard.com>
+ * @copyright Amsterdam Standard Sp. Z o.o.
+ * @homepage http://vegas-cmf.github.io
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Vegas\Mvc\View\Engine\Volt\Helper;
+
+use Vegas\Mvc\View\Engine\Volt\VoltHelperAbstract;
+
+/**
+ * Class MethodExists
+ * @package Vegas\Mvc\View\Engine\Volt\Helper
+ */
+class MethodExists extends VoltHelperAbstract
+{
+
+    /**
+     * Proxies to method_exists() PHP function
+     *
+     * @return string
+     */
+    public function getHelper()
+    {
+        return 'method_exists';
+    }
+}

--- a/tests/Mvc/View/Engine/VoltTest.php
+++ b/tests/Mvc/View/Engine/VoltTest.php
@@ -29,6 +29,8 @@ class VoltTest extends TestCase
 
         $compiler = $volt->getCompiler();
 
+        $this->assertEquals('<?php echo method_exists($object, \'method\'); ?>', $compiler->compileString('{{ methodExists(object, "method") }}'));
+
         $this->assertEquals('<?php echo (new \Vegas\Tag\ShortenText())->prepare(\'foo\',100, "..."); ?>', $compiler->compileString('{{ shortenText("foo") }}'));
         $this->assertEquals('<?php echo (new \Vegas\Tag\ShortenText())->prepare(\'foo\',50, \'bar\'); ?>', $compiler->compileString('{{ shortenText("foo", 50, "bar") }}'));
 


### PR DESCRIPTION
Trivial fix which allows to skip copy-pasting CRUD templates in projects.